### PR TITLE
Remove IsExternalInit

### DIFF
--- a/src/HaveIBeenPwned.Client.Abstractions/Internals/IsExternalInit.cs
+++ b/src/HaveIBeenPwned.Client.Abstractions/Internals/IsExternalInit.cs
@@ -1,4 +1,0 @@
-﻿namespace System.Runtime.CompilerServices;
-
-/// <summary></summary>
-public class IsExternalInit { }


### PR DESCRIPTION
Remove `IsExternalInit` since we target at net6.0 now, there's no need to use it